### PR TITLE
[#17] feat: 채팅방 목록 조회 API 구현 및 레이어별 에러 구조 도입

### DIFF
--- a/internal/room/adapter/in/http/error/room_error.go
+++ b/internal/room/adapter/in/http/error/room_error.go
@@ -6,14 +6,16 @@ import (
 
 	"github.com/kjuiop/live-platform-go/internal/room/domain"
 	roomin "github.com/kjuiop/live-platform-go/internal/room/port/in"
+	serrors "github.com/kjuiop/live-platform-go/internal/shared/errors"
 )
 
 const (
-	ErrCodeRoomNotFound = "R4401"
-	ErrCodeCreateFailed = "R5001"
-	ErrCodeDeleteFailed = "R5002"
-	ErrCodeGetFailed    = "R5003"
-	ErrCodeUnknown      = "UNKNOWN"
+	ErrCodeRoomNotFound  = "R4401"
+	ErrCodeInvalidParams = "R4402"
+	ErrCodeCreateFailed  = "R5001"
+	ErrCodeDeleteFailed  = "R5002"
+	ErrCodeGetFailed     = "R5003"
+	ErrCodeUnknown       = "UNKNOWN"
 )
 
 type ErrMapping struct {
@@ -26,6 +28,8 @@ func GetMapping(err error) ErrMapping {
 	switch {
 	case errors.Is(err, domain.ErrRoomNotFound):
 		return ErrMapping{http.StatusNotFound, ErrCodeRoomNotFound, "not found chat room"}
+	case errors.Is(err, serrors.ErrInvalidRequest):
+		return ErrMapping{http.StatusBadRequest, ErrCodeInvalidParams, "invalid request body"}
 	case errors.Is(err, roomin.ErrCreateChatRoomFailed):
 		return ErrMapping{http.StatusInternalServerError, ErrCodeCreateFailed, "failed to create chat room"}
 	case errors.Is(err, roomin.ErrDeleteChatRoomFailed):

--- a/internal/room/adapter/in/http/error/room_error.go
+++ b/internal/room/adapter/in/http/error/room_error.go
@@ -1,14 +1,18 @@
 package error
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/kjuiop/live-platform-go/internal/room/domain"
-	serrors "github.com/kjuiop/live-platform-go/internal/shared/errors"
+	roomin "github.com/kjuiop/live-platform-go/internal/room/port/in"
 )
 
 const (
 	ErrCodeRoomNotFound = "R4401"
+	ErrCodeCreateFailed = "R5001"
+	ErrCodeDeleteFailed = "R5002"
+	ErrCodeGetFailed    = "R5003"
 	ErrCodeUnknown      = "UNKNOWN"
 )
 
@@ -18,20 +22,17 @@ type ErrMapping struct {
 	Msg        string
 }
 
-var DomainErrMap = map[error]ErrMapping{
-	domain.ErrRoomNotFound:    {http.StatusNotFound, ErrCodeRoomNotFound, "not found chat room"},
-	serrors.ErrInvalidRequest: {http.StatusBadRequest, serrors.CodeInvalidRequest, "invalid request body"},
-	serrors.ErrRedisSave:      {http.StatusInternalServerError, serrors.CodeRedisSave, "internal redis error occurred"},
-	serrors.ErrRedisDelete:    {http.StatusInternalServerError, serrors.CodeRedisDelete, "internal redis error occurred"},
-}
-
 func GetMapping(err error) ErrMapping {
-	if m, ok := DomainErrMap[err]; ok {
-		return m
-	}
-	return ErrMapping{
-		HttpStatus: http.StatusInternalServerError,
-		ErrorCode:  ErrCodeUnknown,
-		Msg:        "unknown error",
+	switch {
+	case errors.Is(err, domain.ErrRoomNotFound):
+		return ErrMapping{http.StatusNotFound, ErrCodeRoomNotFound, "not found chat room"}
+	case errors.Is(err, roomin.ErrCreateChatRoomFailed):
+		return ErrMapping{http.StatusInternalServerError, ErrCodeCreateFailed, "failed to create chat room"}
+	case errors.Is(err, roomin.ErrDeleteChatRoomFailed):
+		return ErrMapping{http.StatusInternalServerError, ErrCodeDeleteFailed, "failed to delete chat room"}
+	case errors.Is(err, roomin.ErrGetChatRoomsFailed):
+		return ErrMapping{http.StatusInternalServerError, ErrCodeGetFailed, "failed to get chat rooms"}
+	default:
+		return ErrMapping{http.StatusInternalServerError, ErrCodeUnknown, "unknown error"}
 	}
 }

--- a/internal/room/adapter/in/http/form/room.go
+++ b/internal/room/adapter/in/http/form/room.go
@@ -13,3 +13,8 @@ type RoomResponse struct {
 	BroadcastKey string `json:"broadcast_key,omitempty"`
 	CreatedAt    int64  `json:"created_at,omitempty"`
 }
+
+type RoomListResponse struct {
+	Rooms []RoomResponse `json:"rooms"`
+	Total int            `json:"total"`
+}

--- a/internal/room/adapter/in/http/room_handler.go
+++ b/internal/room/adapter/in/http/room_handler.go
@@ -32,6 +32,7 @@ func (r *RoomHandler) RegisterRoutes(router gin.IRouter) {
 	group := router.Group("/rooms")
 	group.POST("/", r.CreateChatRoom)
 	group.DELETE("/:roomId", r.DeleteChatRoom)
+	group.GET("/", r.GetChatRooms)
 }
 
 func (r *RoomHandler) successResponse(c *gin.Context, statusCode int, data interface{}) {

--- a/internal/room/adapter/in/http/room_handler.go
+++ b/internal/room/adapter/in/http/room_handler.go
@@ -68,7 +68,7 @@ func (r *RoomHandler) CreateChatRoom(c *gin.Context) {
 
 	roomInfo := domain.NewRoomInfo(req, r.cfg.Prefix)
 	if err := r.service.CreateChatRoom(ctx, *roomInfo); err != nil {
-		r.failedResponse(c, serrors.ErrRedisSave)
+		r.failedResponse(c, err)
 		return
 	}
 
@@ -97,4 +97,29 @@ func (r *RoomHandler) DeleteChatRoom(c *gin.Context) {
 	}
 
 	c.Status(http.StatusNoContent)
+}
+
+func (r *RoomHandler) GetChatRooms(c *gin.Context) {
+	ctx := c.Request.Context()
+	rooms, err := r.service.GetChatRooms(ctx)
+	if err != nil {
+		r.failedResponse(c, err)
+		return
+	}
+
+	roomRes := make([]form.RoomResponse, len(rooms))
+	for i, room := range rooms {
+		roomRes[i] = form.RoomResponse{
+			RoomId:       room.RoomId,
+			CustomerId:   room.CustomerId,
+			ChannelKey:   room.ChannelKey,
+			BroadcastKey: room.BroadcastKey,
+			CreatedAt:    room.CreatedAt,
+		}
+	}
+
+	r.successResponse(c, http.StatusOK, form.RoomListResponse{
+		Rooms: roomRes,
+		Total: len(roomRes),
+	})
 }

--- a/internal/room/adapter/in/http/room_handler_test.go
+++ b/internal/room/adapter/in/http/room_handler_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/kjuiop/live-platform-go/config"
+	rerror "github.com/kjuiop/live-platform-go/internal/room/adapter/in/http/error"
 	"github.com/kjuiop/live-platform-go/internal/room/domain"
-	serrors "github.com/kjuiop/live-platform-go/internal/shared/errors"
 )
 
 var testClient *TestClient
@@ -27,9 +27,10 @@ type TestClient struct {
 }
 
 type mockRoomService struct {
-	createChatRoomErr error
-	deleteChatRoomErr error
-	getChatRoomsErr   error
+	createChatRoomErr  error
+	deleteChatRoomErr  error
+	getChatRoomsResult []domain.RoomInfo
+	getChatRoomsErr    error
 }
 
 func (m *mockRoomService) CreateChatRoom(_ context.Context, _ domain.RoomInfo) error {
@@ -40,8 +41,8 @@ func (m *mockRoomService) DeleteChatRoom(_ context.Context, _ string) error {
 	return m.deleteChatRoomErr
 }
 
-func (m *mockRoomService) GetChatRooms(ctx context.Context) ([]domain.RoomInfo, error) {
-	return nil, m.getChatRoomsErr
+func (m *mockRoomService) GetChatRooms(_ context.Context) ([]domain.RoomInfo, error) {
+	return m.getChatRoomsResult, m.getChatRoomsErr
 }
 
 func TestMain(m *testing.M) {
@@ -148,6 +149,90 @@ func TestCreateRoom(t *testing.T) {
 	}
 }
 
+func TestGetChatRooms(t *testing.T) {
+	tests := []struct {
+		name               string
+		getChatRoomsResult []domain.RoomInfo
+		getChatRoomsErr    error
+		wantCode           int
+		wantTotal          int
+		wantErrorCode      string
+	}{
+		{
+			name:      "빈 목록 반환 - 200",
+			wantCode:  http.StatusOK,
+			wantTotal: 0,
+		},
+		{
+			name: "채팅방 목록 반환 - 200",
+			getChatRoomsResult: []domain.RoomInfo{
+				{RoomId: "room-1", CustomerId: "c1", ChannelKey: "ch-abc", BroadcastKey: "bc-xyz", CreatedAt: 1000},
+				{RoomId: "room-2", CustomerId: "c2", ChannelKey: "ch-def", BroadcastKey: "bc-uvw", CreatedAt: 2000},
+			},
+			wantCode:  http.StatusOK,
+			wantTotal: 2,
+		},
+		{
+			name:            "GetChatRooms 실패 - 500",
+			getChatRoomsErr: roomin.ErrGetChatRoomsFailed,
+			wantCode:        http.StatusInternalServerError,
+			wantErrorCode:   rerror.ErrCodeGetFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := testClient.roomHandler.service.(*mockRoomService)
+			svc.getChatRoomsResult = tt.getChatRoomsResult
+			svc.getChatRoomsErr = tt.getChatRoomsErr
+
+			req, err := http.NewRequest(
+				http.MethodGet,
+				testClient.srv.URL+"/api/v1/rooms/",
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.wantCode {
+				t.Errorf("status code: got %d, want %d", resp.StatusCode, tt.wantCode)
+			}
+
+			var body map[string]interface{}
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+
+			if tt.wantErrorCode != "" {
+				if got, _ := body["error_code"].(string); got != tt.wantErrorCode {
+					t.Errorf("error_code: got %q, want %q", got, tt.wantErrorCode)
+				}
+				return
+			}
+
+			result, ok := body["result"].(map[string]interface{})
+			if !ok {
+				t.Fatal("result field missing in response")
+			}
+			total, _ := result["total"].(float64)
+			if int(total) != tt.wantTotal {
+				t.Errorf("total: got %d, want %d", int(total), tt.wantTotal)
+			}
+			rooms, _ := result["rooms"].([]interface{})
+			if len(rooms) != tt.wantTotal {
+				t.Errorf("rooms length: got %d, want %d", len(rooms), tt.wantTotal)
+			}
+		})
+	}
+}
+
 func TestDeleteRoom(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -172,7 +257,7 @@ func TestDeleteRoom(t *testing.T) {
 			roomId:            "room-abc-123",
 			deleteChatRoomErr: roomin.ErrDeleteChatRoomFailed,
 			wantCode:          http.StatusInternalServerError,
-			wantErrorCode:     serrors.CodeRedisDelete,
+			wantErrorCode:     rerror.ErrCodeDeleteFailed,
 		},
 	}
 

--- a/internal/room/adapter/in/http/room_handler_test.go
+++ b/internal/room/adapter/in/http/room_handler_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"testing"
 
+	roomin "github.com/kjuiop/live-platform-go/internal/room/port/in"
+
 	"github.com/gin-gonic/gin"
 
 	"github.com/kjuiop/live-platform-go/config"
@@ -27,6 +29,7 @@ type TestClient struct {
 type mockRoomService struct {
 	createChatRoomErr error
 	deleteChatRoomErr error
+	getChatRoomsErr   error
 }
 
 func (m *mockRoomService) CreateChatRoom(_ context.Context, _ domain.RoomInfo) error {
@@ -35,6 +38,10 @@ func (m *mockRoomService) CreateChatRoom(_ context.Context, _ domain.RoomInfo) e
 
 func (m *mockRoomService) DeleteChatRoom(_ context.Context, _ string) error {
 	return m.deleteChatRoomErr
+}
+
+func (m *mockRoomService) GetChatRooms(ctx context.Context) ([]domain.RoomInfo, error) {
+	return nil, m.getChatRoomsErr
 }
 
 func TestMain(m *testing.M) {
@@ -163,7 +170,7 @@ func TestDeleteRoom(t *testing.T) {
 		{
 			name:              "DeleteChatRoom 실패 - 500",
 			roomId:            "room-abc-123",
-			deleteChatRoomErr: serrors.ErrRedisDelete,
+			deleteChatRoomErr: roomin.ErrDeleteChatRoomFailed,
 			wantCode:          http.StatusInternalServerError,
 			wantErrorCode:     serrors.CodeRedisDelete,
 		},

--- a/internal/room/adapter/out/redis/room_repository.go
+++ b/internal/room/adapter/out/redis/room_repository.go
@@ -55,7 +55,7 @@ func (r *RoomRedisRepository) SaveRoom(ctx context.Context, room domain.RoomInfo
 		room.RoomId,
 	}
 	if err := r.redis.RunScript(ctx, lua.SaveRoomScript, keys, args...); err != nil {
-		return err
+		return fmt.Errorf("%w: %w", serrors.ErrRepoSave, err)
 	}
 	return nil
 }
@@ -67,7 +67,7 @@ func (r *RoomRedisRepository) DeleteRoom(ctx context.Context, roomId string) err
 	}
 	cmd, err := r.redis.RunScriptResult(ctx, lua.DeleteRoomScript, keys, roomId)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", serrors.ErrRepoDelete, err)
 	}
 	result, err := cmd.Int()
 	if err != nil {

--- a/internal/room/adapter/out/redis/room_repository.go
+++ b/internal/room/adapter/out/redis/room_repository.go
@@ -108,7 +108,11 @@ func (r *RoomRedisRepository) GetRooms(ctx context.Context) ([]domain.RoomInfo, 
 			slog.Warn("GetRooms: room key has expired, skipping", "roomKey", keys[i])
 			continue
 		}
-		createdAt, _ := strconv.ParseInt(m["created_at"], 10, 64)
+		createdAt, err := strconv.ParseInt(m["created_at"], 10, 64)
+		if err != nil {
+			slog.Warn("GetRooms: invalid created_at, skipping", "roomId", m["room_id"], "value", m["created_at"])
+			continue
+		}
 		rooms = append(rooms, domain.RoomInfo{
 			RoomId:       m["room_id"],
 			CustomerId:   m["customer_id"],

--- a/internal/room/adapter/out/redis/room_repository.go
+++ b/internal/room/adapter/out/redis/room_repository.go
@@ -3,7 +3,11 @@ package redis
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strconv"
 	"time"
+
+	serrors "github.com/kjuiop/live-platform-go/internal/shared/errors"
 
 	"github.com/kjuiop/live-platform-go/internal/room/adapter/out/redis/lua"
 
@@ -73,4 +77,45 @@ func (r *RoomRedisRepository) DeleteRoom(ctx context.Context, roomId string) err
 		return domain.ErrRoomNotFound
 	}
 	return nil
+}
+
+func (r *RoomRedisRepository) GetRooms(ctx context.Context) ([]domain.RoomInfo, error) {
+	// 1. room-map 에서 모든 roomId 조회
+	roomIds, err := r.redis.HVals(ctx, roomMapKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", serrors.ErrRepoGet, err)
+	}
+	if len(roomIds) == 0 {
+		return []domain.RoomInfo{}, nil
+	}
+
+	// 2. 각 roomId의 키 생성
+	keys := make([]string, len(roomIds))
+	for i, id := range roomIds {
+		keys[i] = roomKey(id)
+	}
+
+	// 3. Pipeline 으로 HGETALL 일괄 조회
+	results, err := r.redis.HGetAllPipeline(ctx, keys)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", serrors.ErrRepoGet, err)
+	}
+
+	// 4. 결과 파싱 (TTL 만료된 방 skip)
+	rooms := make([]domain.RoomInfo, 0, len(results))
+	for i, m := range results {
+		if len(m) == 0 {
+			slog.Warn("GetRooms: room key has expired, skipping", "roomKey", keys[i])
+			continue
+		}
+		createdAt, _ := strconv.ParseInt(m["created_at"], 10, 64)
+		rooms = append(rooms, domain.RoomInfo{
+			RoomId:       m["room_id"],
+			CustomerId:   m["customer_id"],
+			ChannelKey:   m["channel_key"],
+			BroadcastKey: m["broadcast_key"],
+			CreatedAt:    createdAt,
+		})
+	}
+	return rooms, nil
 }

--- a/internal/room/application/room_service.go
+++ b/internal/room/application/room_service.go
@@ -3,12 +3,13 @@ package application
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sort"
 	"time"
 
 	"github.com/kjuiop/live-platform-go/internal/room/domain"
 	roomin "github.com/kjuiop/live-platform-go/internal/room/port/in"
 	roomoutport "github.com/kjuiop/live-platform-go/internal/room/port/out"
-	serrors "github.com/kjuiop/live-platform-go/internal/shared/errors"
 )
 
 var _ roomin.RoomService = (*RoomServiceImpl)(nil)
@@ -30,7 +31,7 @@ func (r *RoomServiceImpl) CreateChatRoom(ctx context.Context, room domain.RoomIn
 	defer cancel()
 
 	if err := r.roomRepo.SaveRoom(ctx, room); err != nil {
-		return serrors.ErrRedisSave
+		return fmt.Errorf("%w: %w", roomin.ErrCreateChatRoomFailed, err)
 	}
 
 	return nil
@@ -44,7 +45,22 @@ func (r *RoomServiceImpl) DeleteChatRoom(ctx context.Context, roomId string) err
 		if errors.Is(err, domain.ErrRoomNotFound) {
 			return domain.ErrRoomNotFound
 		}
-		return serrors.ErrRedisDelete
+		return fmt.Errorf("%w: %w", roomin.ErrDeleteChatRoomFailed, err)
 	}
 	return nil
+}
+
+func (r *RoomServiceImpl) GetChatRooms(ctx context.Context) ([]domain.RoomInfo, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.contextTimeout)
+	defer cancel()
+
+	rooms, err := r.roomRepo.GetRooms(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", roomin.ErrGetChatRoomsFailed, err)
+	}
+
+	sort.Slice(rooms, func(i, j int) bool {
+		return rooms[i].CreatedAt > rooms[j].CreatedAt
+	})
+	return rooms, nil
 }

--- a/internal/room/application/room_service_test.go
+++ b/internal/room/application/room_service_test.go
@@ -83,7 +83,7 @@ func TestRoomServiceImpl_DeleteChatRoom(t *testing.T) {
 			name:        "기타 레포지토리 에러 → ErrRedisDelete 로 변환",
 			deleteErr:   repoErr,
 			wantErr:     true,
-			wantWrapped: serrors.ErrRedisDelete,
+			wantWrapped: serrors.ErrRepoDelete,
 		},
 	}
 
@@ -105,4 +105,9 @@ func TestRoomServiceImpl_DeleteChatRoom(t *testing.T) {
 			}
 		})
 	}
+}
+
+func (m *mockRoomRepository) GetRooms(ctx context.Context) ([]domain.RoomInfo, error) {
+	//TODO implement me
+	panic("implement me")
 }

--- a/internal/room/application/room_service_test.go
+++ b/internal/room/application/room_service_test.go
@@ -7,12 +7,14 @@ import (
 	"time"
 
 	"github.com/kjuiop/live-platform-go/internal/room/domain"
-	serrors "github.com/kjuiop/live-platform-go/internal/shared/errors"
+	roomin "github.com/kjuiop/live-platform-go/internal/room/port/in"
 )
 
 type mockRoomRepository struct {
-	saveErr   error
-	deleteErr error
+	saveErr        error
+	deleteErr      error
+	getRoomsResult []domain.RoomInfo
+	getRoomsErr    error
 }
 
 func (m *mockRoomRepository) DeleteRoom(_ context.Context, _ string) error {
@@ -21,6 +23,10 @@ func (m *mockRoomRepository) DeleteRoom(_ context.Context, _ string) error {
 
 func (m *mockRoomRepository) SaveRoom(_ context.Context, _ domain.RoomInfo) error {
 	return m.saveErr
+}
+
+func (m *mockRoomRepository) GetRooms(_ context.Context) ([]domain.RoomInfo, error) {
+	return m.getRoomsResult, m.getRoomsErr
 }
 
 func TestRoomServiceImpl_CreateChatRoom(t *testing.T) {
@@ -80,10 +86,10 @@ func TestRoomServiceImpl_DeleteChatRoom(t *testing.T) {
 			wantNotFound: true,
 		},
 		{
-			name:        "기타 레포지토리 에러 → ErrRedisDelete 로 변환",
+			name:        "기타 레포지토리 에러 → ErrDeleteChatRoomFailed 로 변환",
 			deleteErr:   repoErr,
 			wantErr:     true,
-			wantWrapped: serrors.ErrRepoDelete,
+			wantWrapped: roomin.ErrDeleteChatRoomFailed,
 		},
 	}
 
@@ -107,7 +113,66 @@ func TestRoomServiceImpl_DeleteChatRoom(t *testing.T) {
 	}
 }
 
-func (m *mockRoomRepository) GetRooms(ctx context.Context) ([]domain.RoomInfo, error) {
-	//TODO implement me
-	panic("implement me")
+func TestRoomServiceImpl_GetChatRooms(t *testing.T) {
+	tests := []struct {
+		name           string
+		getRoomsResult []domain.RoomInfo
+		getRoomsErr    error
+		wantErr        bool
+		wantErrIs      error
+		wantLen        int
+		checkOrder     bool
+	}{
+		{
+			name:           "빈 목록 반환",
+			getRoomsResult: []domain.RoomInfo{},
+			wantLen:        0,
+		},
+		{
+			name: "최신순 정렬",
+			getRoomsResult: []domain.RoomInfo{
+				{RoomId: "room-1", CreatedAt: 1000},
+				{RoomId: "room-2", CreatedAt: 3000},
+				{RoomId: "room-3", CreatedAt: 2000},
+			},
+			wantLen:    3,
+			checkOrder: true,
+		},
+		{
+			name:        "Repository 에러 → ErrGetChatRoomsFailed 래핑",
+			getRoomsErr: errors.New("redis error"),
+			wantErr:     true,
+			wantErrIs:   roomin.ErrGetChatRoomsFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockRoomRepository{
+				getRoomsResult: tt.getRoomsResult,
+				getRoomsErr:    tt.getRoomsErr,
+			}
+			svc := NewRoomService(5*time.Second, repo)
+
+			rooms, err := svc.GetChatRooms(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetChatRooms() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErrIs != nil && !errors.Is(err, tt.wantErrIs) {
+				t.Errorf("GetChatRooms() expected errors.Is(%v), got %v", tt.wantErrIs, err)
+			}
+			if !tt.wantErr && len(rooms) != tt.wantLen {
+				t.Errorf("GetChatRooms() len = %d, want %d", len(rooms), tt.wantLen)
+			}
+			if tt.checkOrder {
+				for i := 1; i < len(rooms); i++ {
+					if rooms[i-1].CreatedAt < rooms[i].CreatedAt {
+						t.Errorf("GetChatRooms() not sorted: rooms[%d].CreatedAt=%d < rooms[%d].CreatedAt=%d",
+							i-1, rooms[i-1].CreatedAt, i, rooms[i].CreatedAt)
+					}
+				}
+			}
+		})
+	}
 }

--- a/internal/room/port/in/errors.go
+++ b/internal/room/port/in/errors.go
@@ -1,0 +1,9 @@
+package in
+
+import "errors"
+
+var (
+	ErrCreateChatRoomFailed = errors.New("failed to create chat room")
+	ErrDeleteChatRoomFailed = errors.New("failed to delete chat room")
+	ErrGetChatRoomsFailed   = errors.New("failed to get chat rooms")
+)

--- a/internal/room/port/in/room_service.go
+++ b/internal/room/port/in/room_service.go
@@ -9,4 +9,5 @@ import (
 type RoomService interface {
 	CreateChatRoom(ctx context.Context, room domain.RoomInfo) error
 	DeleteChatRoom(ctx context.Context, roomId string) error
+	GetChatRooms(ctx context.Context) ([]domain.RoomInfo, error)
 }

--- a/internal/room/port/out/room_repository.go
+++ b/internal/room/port/out/room_repository.go
@@ -9,4 +9,5 @@ import (
 type RoomRepository interface {
 	SaveRoom(ctx context.Context, room domain.RoomInfo) error
 	DeleteRoom(ctx context.Context, roomId string) error
+	GetRooms(ctx context.Context) ([]domain.RoomInfo, error)
 }

--- a/internal/shared/errors/errors.go
+++ b/internal/shared/errors/errors.go
@@ -9,6 +9,7 @@ const (
 	CodeInternalError  = "S5001"
 	CodeRedisSave      = "S5002"
 	CodeRedisDelete    = "S5003"
+	CodeRedisGet       = "S5004"
 )
 
 var codeToMessage = map[string]string{
@@ -16,14 +17,16 @@ var codeToMessage = map[string]string{
 	CodeInvalidRequest: "invalid request body",
 	CodeEmptyParam:     "invalid params",
 	CodeInternalError:  "internal server error",
-	CodeRedisSave:      "internal redis error occurred",
-	CodeRedisDelete:    "internal redis error occurred",
+	CodeRedisSave:      "internal storage error occurred",
+	CodeRedisDelete:    "internal storage error occurred",
+	CodeRedisGet:       "internal storage error occurred",
 }
 
 var (
 	ErrInvalidRequest = errors.New("invalid request")
-	ErrRedisSave      = errors.New("redis save error")
-	ErrRedisDelete    = errors.New("redis delete error")
+	ErrRepoSave       = errors.New("repository save error")
+	ErrRepoDelete     = errors.New("repository delete error")
+	ErrRepoGet        = errors.New("repository get error")
 )
 
 func GetCustomMessage(code string) string {

--- a/internal/shared/errors/errors.go
+++ b/internal/shared/errors/errors.go
@@ -7,9 +7,9 @@ const (
 	CodeInvalidRequest = "S4401"
 	CodeEmptyParam     = "S4402"
 	CodeInternalError  = "S5001"
-	CodeRedisSave      = "S5002"
-	CodeRedisDelete    = "S5003"
-	CodeRedisGet       = "S5004"
+	CodeRepoSave       = "S5002"
+	CodeRepoDelete     = "S5003"
+	CodeRepoGet        = "S5004"
 )
 
 var codeToMessage = map[string]string{
@@ -17,9 +17,9 @@ var codeToMessage = map[string]string{
 	CodeInvalidRequest: "invalid request body",
 	CodeEmptyParam:     "invalid params",
 	CodeInternalError:  "internal server error",
-	CodeRedisSave:      "internal storage error occurred",
-	CodeRedisDelete:    "internal storage error occurred",
-	CodeRedisGet:       "internal storage error occurred",
+	CodeRepoSave:       "internal storage error occurred",
+	CodeRepoDelete:     "internal storage error occurred",
+	CodeRepoGet:        "internal storage error occurred",
 }
 
 var (

--- a/platform/redis/redis.go
+++ b/platform/redis/redis.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -65,6 +66,46 @@ func (r *Client) RunScript(ctx context.Context, script *redis.Script, keys []str
 func (r *Client) RunScriptResult(ctx context.Context, script *redis.Script, keys []string, args ...interface{}) (*redis.Cmd, error) {
 	cmd := script.Run(ctx, r.client, keys, args...)
 	return cmd, cmd.Err()
+}
+
+func (r *Client) HVals(ctx context.Context, key string) ([]string, error) {
+	vals, err := r.client.HVals(ctx, key).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("HVals %s: %w", key, err)
+	}
+	return vals, nil
+}
+
+func (r *Client) HGetAllPipeline(ctx context.Context, keys []string) ([]map[string]string, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	pipe := r.client.TxPipeline()
+	// command 를 실행할 목록 배열을 저장
+	cmds := make([]*redis.MapStringStringCmd, len(keys))
+	for i, key := range keys {
+		cmds[i] = pipe.HGetAll(ctx, key)
+	}
+
+	// command 실행
+	if _, err := pipe.Exec(ctx); err != nil && !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("HGetAllPipeline exec: %w", err)
+	}
+
+	// 결과를 map[string]string 형태로 변환하여 반환
+	results := make([]map[string]string, len(keys))
+	for i, cmd := range cmds {
+		m, err := cmd.Result()
+		if err != nil && !errors.Is(err, redis.Nil) {
+			return nil, fmt.Errorf("HGetAllPipeline cmd[%d]: %w", i, err)
+		}
+		results[i] = m
+	}
+	return results, nil
 }
 
 func (r *Client) Close() {

--- a/platform/redis/redis.go
+++ b/platform/redis/redis.go
@@ -84,7 +84,7 @@ func (r *Client) HGetAllPipeline(ctx context.Context, keys []string) ([]map[stri
 		return nil, nil
 	}
 
-	pipe := r.client.TxPipeline()
+	pipe := r.client.Pipeline()
 	// command 를 실행할 목록 배열을 저장
 	cmds := make([]*redis.MapStringStringCmd, len(keys))
 	for i, key := range keys {


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 동시성/경쟁 조건 이슈 (Goroutine, Channel)
  2. 성능 영향 (Kafka 처리량, WebSocket 연결 수, Redis 조회)
  3. 장애/롤백 리스크
  4. 운영 관점 (로그, 모니터링, 알람)
-->

# Summary
`GET /api/v1/rooms` 엔드포인트를 추가해 활성 채팅방 목록을 최신순으로 반환한다.
Redis Lua 스크립트 대신 Pipeline 방식을 사용하고, 헥사고날 아키텍처의 레이어별 에러 분리 구조를 도입했다.


### Issue
- closes #17


### Why
- 클라이언트(프론트엔드 셀렉박스)에서 입장 가능한 채팅방 목록을 조회할 API가 없었다.
- 기존에 `ErrRedisSave`, `ErrRedisDelete` 처럼 인프라 이름이 노출된 에러 구조를 인프라 독립적으로 개선할 필요가 있었다.
- Service 레이어가 Redis 에러를 직접 반환해 헥사고날 아키텍처 원칙(레이어 간 역할 분리)에 어긋났다.


### What
- `GET /api/v1/rooms` 엔드포인트 추가 — 활성 채팅방 목록을 `CreatedAt` 최신순으로 반환
- `platform/redis`: `HVals`, `HGetAllPipeline` 메서드 추가 (Lua 스크립트 없이 Pipeline으로 N+1 왕복을 1회로 처리)
- `port/in/errors.go` 신규: Service 계층 에러 (`ErrCreateChatRoomFailed`, `ErrDeleteChatRoomFailed`, `ErrGetChatRoomsFailed`)
- `shared/errors`: `ErrRedisSave` → `ErrRepoSave`, `ErrRedisDelete` → `ErrRepoDelete` 이름 교체, `ErrRepoGet` 추가
- `room_error.go`: `DomainErrMap[err]` 직접 맵 조회 → `errors.Is` switch 방식으로 교체, `ErrInvalidRequest` 매핑 복구


### How
- **목록 조회에 Lua 대신 Pipeline 선택**: 읽기 전용 작업에 Lua를 쓰면 Redis 전체가 블로킹됨. Pipeline은 네트워크 왕복 횟수는 동일(1회)하면서 서버 블로킹 없음
- **레이어별 에러 분리**:
  - Repository(`adapter/out`): Redis 원본 에러 → `serrors.ErrRepoGet` 으로 변환
  - Service(`application`): repo 에러 → `roomin.ErrGetChatRoomsFailed` 로 래핑 (`fmt.Errorf("%w: %w", ...)`)
  - Handler(`adapter/in`): `errors.Is`로 service 에러 탐색 → HTTP 응답 매핑
- TTL 만료된 방은 `HGETALL` 결과가 빈 map으로 반환되므로 Repository에서 skip 처리


### Test
- `TestRoomServiceImpl_GetChatRooms`: 빈 목록 / CreatedAt 최신순 정렬 / Repository 에러 → ErrGetChatRoomsFailed 래핑 확인
- `TestGetChatRooms`: 빈 목록 200 / 목록 반환 200(total 검증) / 서비스 에러 500(error_code R5003) 확인
- `make test` 전체 통과