### PR TITLE
[#19] room-map 고아 필드 문제를 Redis HEXPIRE 기반 TTL로 해결

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LDFLAGS+=-s -w
 
 LOCAL_PREFIX=github.com/kjuiop/live-platform-go
 
-.PHONY: build api-build worker-build test fmt lint target-version build_num clean
+.PHONY: build api-build worker-build test fmt lint target-version build_num clean redisinsight
 
 api: config fmt lint api-build
 
@@ -79,6 +79,9 @@ git-hooks:
 	@chmod +x .githooks/commit-msg
 	@chmod +x .githooks/pre-commit
 	@echo "Done. (commit-msg & pre-commit hook active)"
+
+redisinsight:
+	docker compose --profile dev-tools up redisinsight -d
 
 clean:
 	@echo "Cleaning up..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,17 @@ services:
       retries: 3
     restart: unless-stopped
 
+  redisinsight:
+    image: redis/redisinsight:latest
+    container_name: live-platform-redisinsight
+    ports:
+      - "5540:5540"
+    volumes:
+      - redisinsight-data:/data
+    depends_on:
+      - redis
+    restart: unless-stopped
+
 volumes:
   redis-data:
+  redisinsight-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   redis:
-    image: redis:7-alpine
+    image: redis:7.4-alpine
     container_name: live-platform-redis
     ports:
       - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,10 @@ services:
     restart: unless-stopped
 
   redisinsight:
-    image: redis/redisinsight:latest
+    image: redis/redisinsight:2.66.0
     container_name: live-platform-redisinsight
+    profiles:
+      - dev-tools
     ports:
       - "5540:5540"
     volumes:

--- a/internal/room/adapter/in/http/error/room_error.go
+++ b/internal/room/adapter/in/http/error/room_error.go
@@ -4,8 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/kjuiop/live-platform-go/internal/room/domain"
-	roomin "github.com/kjuiop/live-platform-go/internal/room/port/in"
+	roomerr "github.com/kjuiop/live-platform-go/internal/room/domain/errors"
 	serrors "github.com/kjuiop/live-platform-go/internal/shared/errors"
 )
 
@@ -26,15 +25,15 @@ type ErrMapping struct {
 
 func GetMapping(err error) ErrMapping {
 	switch {
-	case errors.Is(err, domain.ErrRoomNotFound):
-		return ErrMapping{http.StatusNotFound, ErrCodeRoomNotFound, "not found chat room"}
 	case errors.Is(err, serrors.ErrInvalidRequest):
 		return ErrMapping{http.StatusBadRequest, ErrCodeInvalidParams, "invalid request body"}
-	case errors.Is(err, roomin.ErrCreateChatRoomFailed):
+	case errors.Is(err, roomerr.ErrRoomNotFound):
+		return ErrMapping{http.StatusNotFound, ErrCodeRoomNotFound, "not found chat room"}
+	case errors.Is(err, roomerr.ErrCreateChatRoomFailed):
 		return ErrMapping{http.StatusInternalServerError, ErrCodeCreateFailed, "failed to create chat room"}
-	case errors.Is(err, roomin.ErrDeleteChatRoomFailed):
+	case errors.Is(err, roomerr.ErrDeleteChatRoomFailed):
 		return ErrMapping{http.StatusInternalServerError, ErrCodeDeleteFailed, "failed to delete chat room"}
-	case errors.Is(err, roomin.ErrGetChatRoomsFailed):
+	case errors.Is(err, roomerr.ErrGetChatRoomsFailed):
 		return ErrMapping{http.StatusInternalServerError, ErrCodeGetFailed, "failed to get chat rooms"}
 	default:
 		return ErrMapping{http.StatusInternalServerError, ErrCodeUnknown, "unknown error"}

--- a/internal/room/adapter/in/http/room_handler_test.go
+++ b/internal/room/adapter/in/http/room_handler_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"testing"
 
-	roomin "github.com/kjuiop/live-platform-go/internal/room/port/in"
+	roomerr "github.com/kjuiop/live-platform-go/internal/room/domain/errors"
 
 	"github.com/gin-gonic/gin"
 
@@ -174,7 +174,7 @@ func TestGetChatRooms(t *testing.T) {
 		},
 		{
 			name:            "GetChatRooms 실패 - 500",
-			getChatRoomsErr: roomin.ErrGetChatRoomsFailed,
+			getChatRoomsErr: roomerr.ErrGetChatRoomsFailed,
 			wantCode:        http.StatusInternalServerError,
 			wantErrorCode:   rerror.ErrCodeGetFailed,
 		},
@@ -249,13 +249,13 @@ func TestDeleteRoom(t *testing.T) {
 		{
 			name:              "존재하지 않는 채팅방 - 404",
 			roomId:            "room-not-found",
-			deleteChatRoomErr: domain.ErrRoomNotFound,
+			deleteChatRoomErr: roomerr.ErrRoomNotFound,
 			wantCode:          http.StatusNotFound,
 		},
 		{
 			name:              "DeleteChatRoom 실패 - 500",
 			roomId:            "room-abc-123",
-			deleteChatRoomErr: roomin.ErrDeleteChatRoomFailed,
+			deleteChatRoomErr: roomerr.ErrDeleteChatRoomFailed,
 			wantCode:          http.StatusInternalServerError,
 			wantErrorCode:     rerror.ErrCodeDeleteFailed,
 		},

--- a/internal/room/adapter/out/redis/lua/room_lua.go
+++ b/internal/room/adapter/out/redis/lua/room_lua.go
@@ -11,6 +11,7 @@ redis.call('HSET', KEYS[1],
     'created_at',     ARGV[5])
 redis.call('EXPIRE', KEYS[1], ARGV[6])
 redis.call('HSET', KEYS[2], ARGV[7], ARGV[8])
+redis.call('HEXPIRE', KEYS[2], ARGV[6], 'FIELDS', 1, ARGV[7])
 return 1
 `)
 

--- a/internal/room/adapter/out/redis/room_repository.go
+++ b/internal/room/adapter/out/redis/room_repository.go
@@ -10,13 +10,14 @@ import (
 	"github.com/kjuiop/live-platform-go/internal/room/adapter/out/redis/lua"
 
 	"github.com/kjuiop/live-platform-go/internal/room/domain"
+	roomerr "github.com/kjuiop/live-platform-go/internal/room/domain/errors"
 	roomoutport "github.com/kjuiop/live-platform-go/internal/room/port/out"
 	"github.com/kjuiop/live-platform-go/platform/redis"
 )
 
 const (
 	roomKeyPrefix = "live:rooms"
-	roomMapKey    = "live:room-map"
+	roomMapKey    = "live:rooms-map"
 	RoomExpire    = time.Duration(7) * 24 * time.Hour
 )
 
@@ -72,7 +73,7 @@ func (r *RoomRedisRepository) DeleteRoom(ctx context.Context, roomId string) err
 		return err
 	}
 	if result == 0 {
-		return fmt.Errorf("roomRepo:DeleteRoom: room not found")
+		return fmt.Errorf("roomRepo:DeleteRoom: %w", roomerr.ErrRoomNotFound)
 	}
 	return nil
 }

--- a/internal/room/adapter/out/redis/room_repository.go
+++ b/internal/room/adapter/out/redis/room_repository.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	roomKeyPrefix = "live-platform-room"
-	roomMapKey    = "live-platform-room-map"
+	roomKeyPrefix = "live:rooms"
+	roomMapKey    = "live:room-map"
 	RoomExpire    = time.Duration(7) * 24 * time.Hour
 )
 

--- a/internal/room/adapter/out/redis/room_repository.go
+++ b/internal/room/adapter/out/redis/room_repository.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	serrors "github.com/kjuiop/live-platform-go/internal/shared/errors"
-
 	"github.com/kjuiop/live-platform-go/internal/room/adapter/out/redis/lua"
 
 	"github.com/kjuiop/live-platform-go/internal/room/domain"
@@ -55,7 +53,7 @@ func (r *RoomRedisRepository) SaveRoom(ctx context.Context, room domain.RoomInfo
 		room.RoomId,
 	}
 	if err := r.redis.RunScript(ctx, lua.SaveRoomScript, keys, args...); err != nil {
-		return fmt.Errorf("%w: %w", serrors.ErrRepoSave, err)
+		return fmt.Errorf("roomRepo.SaveRoom: %w", err)
 	}
 	return nil
 }
@@ -67,14 +65,14 @@ func (r *RoomRedisRepository) DeleteRoom(ctx context.Context, roomId string) err
 	}
 	cmd, err := r.redis.RunScriptResult(ctx, lua.DeleteRoomScript, keys, roomId)
 	if err != nil {
-		return fmt.Errorf("%w: %w", serrors.ErrRepoDelete, err)
+		return fmt.Errorf("roomRepo:DeleteRoom: %w", err)
 	}
 	result, err := cmd.Int()
 	if err != nil {
 		return err
 	}
 	if result == 0 {
-		return domain.ErrRoomNotFound
+		return fmt.Errorf("roomRepo:DeleteRoom: room not found")
 	}
 	return nil
 }
@@ -83,7 +81,7 @@ func (r *RoomRedisRepository) GetRooms(ctx context.Context) ([]domain.RoomInfo, 
 	// 1. room-map 에서 모든 roomId 조회
 	roomIds, err := r.redis.HVals(ctx, roomMapKey)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", serrors.ErrRepoGet, err)
+		return nil, fmt.Errorf("roomRepo.GetRooms: %w", err)
 	}
 	if len(roomIds) == 0 {
 		return []domain.RoomInfo{}, nil
@@ -98,7 +96,7 @@ func (r *RoomRedisRepository) GetRooms(ctx context.Context) ([]domain.RoomInfo, 
 	// 3. Pipeline 으로 HGETALL 일괄 조회
 	results, err := r.redis.HGetAllPipeline(ctx, keys)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", serrors.ErrRepoGet, err)
+		return nil, fmt.Errorf("roomRepo.GetRooms:: %w", err)
 	}
 
 	// 4. 결과 파싱 (TTL 만료된 방 skip)

--- a/internal/room/application/room_service.go
+++ b/internal/room/application/room_service.go
@@ -33,7 +33,7 @@ func (r *RoomServiceImpl) CreateChatRoom(ctx context.Context, room domain.RoomIn
 	defer cancel()
 
 	if err := r.roomRepo.SaveRoom(ctx, room); err != nil {
-		return fmt.Errorf("roomSrv:CreateChatRoom: %w:%w", roomerr.ErrCreateChatRoomFailed, err)
+		return fmt.Errorf("roomSrv:CreateChatRoom: %w: %w", roomerr.ErrCreateChatRoomFailed, err)
 	}
 
 	return nil
@@ -58,7 +58,7 @@ func (r *RoomServiceImpl) GetChatRooms(ctx context.Context) ([]domain.RoomInfo, 
 
 	rooms, err := r.roomRepo.GetRooms(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("roomSrv.GetChatRooms: %w:%w", roomerr.ErrGetChatRoomsFailed, err)
+		return nil, fmt.Errorf("roomSrv.GetChatRooms: %w: %w", roomerr.ErrGetChatRoomsFailed, err)
 	}
 
 	sort.Slice(rooms, func(i, j int) bool {

--- a/internal/room/application/room_service.go
+++ b/internal/room/application/room_service.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"time"
 
+	roomerr "github.com/kjuiop/live-platform-go/internal/room/domain/errors"
+
 	"github.com/kjuiop/live-platform-go/internal/room/domain"
 	roomin "github.com/kjuiop/live-platform-go/internal/room/port/in"
 	roomoutport "github.com/kjuiop/live-platform-go/internal/room/port/out"
@@ -31,7 +33,7 @@ func (r *RoomServiceImpl) CreateChatRoom(ctx context.Context, room domain.RoomIn
 	defer cancel()
 
 	if err := r.roomRepo.SaveRoom(ctx, room); err != nil {
-		return fmt.Errorf("%w: %w", roomin.ErrCreateChatRoomFailed, err)
+		return fmt.Errorf("roomSrv:CreateChatRoom: %w:%w", roomerr.ErrCreateChatRoomFailed, err)
 	}
 
 	return nil
@@ -42,10 +44,10 @@ func (r *RoomServiceImpl) DeleteChatRoom(ctx context.Context, roomId string) err
 	defer cancel()
 
 	if err := r.roomRepo.DeleteRoom(ctx, roomId); err != nil {
-		if errors.Is(err, domain.ErrRoomNotFound) {
-			return domain.ErrRoomNotFound
+		if errors.Is(err, roomerr.ErrRoomNotFound) {
+			return roomerr.ErrRoomNotFound
 		}
-		return fmt.Errorf("%w: %w", roomin.ErrDeleteChatRoomFailed, err)
+		return fmt.Errorf("roomSrv.DeleteChatRoom: %w: %w", roomerr.ErrDeleteChatRoomFailed, err)
 	}
 	return nil
 }
@@ -56,7 +58,7 @@ func (r *RoomServiceImpl) GetChatRooms(ctx context.Context) ([]domain.RoomInfo, 
 
 	rooms, err := r.roomRepo.GetRooms(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", roomin.ErrGetChatRoomsFailed, err)
+		return nil, fmt.Errorf("roomSrv.GetChatRooms: %w:%w", roomerr.ErrGetChatRoomsFailed, err)
 	}
 
 	sort.Slice(rooms, func(i, j int) bool {

--- a/internal/room/application/room_service_test.go
+++ b/internal/room/application/room_service_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
+	roomerr "github.com/kjuiop/live-platform-go/internal/room/domain/errors"
+
 	"github.com/kjuiop/live-platform-go/internal/room/domain"
-	roomin "github.com/kjuiop/live-platform-go/internal/room/port/in"
 )
 
 type mockRoomRepository struct {
@@ -81,7 +82,7 @@ func TestRoomServiceImpl_DeleteChatRoom(t *testing.T) {
 		},
 		{
 			name:         "ErrRoomNotFound 그대로 전달",
-			deleteErr:    domain.ErrRoomNotFound,
+			deleteErr:    roomerr.ErrRoomNotFound,
 			wantErr:      true,
 			wantNotFound: true,
 		},
@@ -89,7 +90,7 @@ func TestRoomServiceImpl_DeleteChatRoom(t *testing.T) {
 			name:        "기타 레포지토리 에러 → ErrDeleteChatRoomFailed 로 변환",
 			deleteErr:   repoErr,
 			wantErr:     true,
-			wantWrapped: roomin.ErrDeleteChatRoomFailed,
+			wantWrapped: roomerr.ErrDeleteChatRoomFailed,
 		},
 	}
 
@@ -103,7 +104,7 @@ func TestRoomServiceImpl_DeleteChatRoom(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DeleteChatRoom() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if tt.wantNotFound && !errors.Is(err, domain.ErrRoomNotFound) {
+			if tt.wantNotFound && !errors.Is(err, roomerr.ErrRoomNotFound) {
 				t.Errorf("DeleteChatRoom() expected ErrRoomNotFound, got %v", err)
 			}
 			if tt.wantWrapped != nil && !errors.Is(err, tt.wantWrapped) {
@@ -142,7 +143,7 @@ func TestRoomServiceImpl_GetChatRooms(t *testing.T) {
 			name:        "Repository 에러 → ErrGetChatRoomsFailed 래핑",
 			getRoomsErr: errors.New("redis error"),
 			wantErr:     true,
-			wantErrIs:   roomin.ErrGetChatRoomsFailed,
+			wantErrIs:   roomerr.ErrGetChatRoomsFailed,
 		},
 	}
 

--- a/internal/room/domain/errors/errors.go
+++ b/internal/room/domain/errors/errors.go
@@ -1,8 +1,9 @@
-package in
+package errors
 
 import "errors"
 
 var (
+	ErrRoomNotFound         = errors.New("room not found")
 	ErrCreateChatRoomFailed = errors.New("failed to create chat room")
 	ErrDeleteChatRoomFailed = errors.New("failed to delete chat room")
 	ErrGetChatRoomsFailed   = errors.New("failed to get chat rooms")

--- a/internal/room/domain/room.go
+++ b/internal/room/domain/room.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -9,10 +8,6 @@ import (
 
 	"github.com/kjuiop/live-platform-go/internal/room/adapter/in/http/form"
 	"github.com/kjuiop/live-platform-go/internal/shared/utils"
-)
-
-var (
-	ErrRoomNotFound = errors.New("room not found")
 )
 
 type RoomInfo struct {

--- a/internal/shared/errors/errors.go
+++ b/internal/shared/errors/errors.go
@@ -7,9 +7,6 @@ const (
 	CodeInvalidRequest = "S4401"
 	CodeEmptyParam     = "S4402"
 	CodeInternalError  = "S5001"
-	CodeRepoSave       = "S5002"
-	CodeRepoDelete     = "S5003"
-	CodeRepoGet        = "S5004"
 )
 
 var codeToMessage = map[string]string{
@@ -17,16 +14,10 @@ var codeToMessage = map[string]string{
 	CodeInvalidRequest: "invalid request body",
 	CodeEmptyParam:     "invalid params",
 	CodeInternalError:  "internal server error",
-	CodeRepoSave:       "internal storage error occurred",
-	CodeRepoDelete:     "internal storage error occurred",
-	CodeRepoGet:        "internal storage error occurred",
 }
 
 var (
 	ErrInvalidRequest = errors.New("invalid request")
-	ErrRepoSave       = errors.New("repository save error")
-	ErrRepoDelete     = errors.New("repository delete error")
-	ErrRepoGet        = errors.New("repository get error")
 )
 
 func GetCustomMessage(code string) string {

--- a/platform/http/middleware/cors.go
+++ b/platform/http/middleware/cors.go
@@ -9,8 +9,8 @@ import (
 
 func SetCorsPolicy() gin.HandlerFunc {
 	return cors.New(cors.Config{
+		AllowAllOrigins:  true,
 		AllowWebSockets:  true,
-		AllowOrigins:     []string{"*"},
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization"},
 		ExposeHeaders:    []string{"Content-Length"},


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 동시성/경쟁 조건 이슈 (Goroutine, Channel)
  2. 성능 영향 (Kafka 처리량, WebSocket 연결 수, Redis 조회)
  3. 장애/롤백 리스크
  4. 운영 관점 (로그, 모니터링, 알람)
-->

# Summary
채팅방 TTL 만료 시 `live:room-map`에 고아 필드가 누적되는 문제를 Redis 7.4의 `HEXPIRE`로 해결한다. Worker 기반 배치 정리 대신 Lua 스크립트에서 room-map 필드에 room key와 동일한 TTL을 원자적으로 설정하는 방식으로 변경했다. 에러 체계 리팩토링 및 Redis key 네이밍 규칙도 함께 적용했다.


### Issue
- closes #19


### Why
- `SaveRoomScript`에서 `live:room:{roomId}`에는 7일 TTL을 설정하지만 `live:room-map`의 필드는 TTL이 없어 TTL 만료된 채팅방의 데이터가 room-map에 영구 잔존했다
- room-map 키 전체에 `EXPIRE`를 걸면 다른 채팅방 필드까지 삭제되므로 부적합했고, Worker 기반 주기적 정리를 대안으로 검토했으나 Redis 7.4의 `HEXPIRE`로 더 단순하게 해결 가능했다


### What
- `docker-compose.yml`: Redis `7-alpine` → `7.4-alpine` 업그레이드, RedisInsight 서비스 추가
- `SaveRoomScript` Lua 스크립트: `HSET live:room-map` 이후 `HEXPIRE live:room-map ARGV[6] FIELDS 1 ARGV[7]` 한 줄 추가
- Redis key 네이밍 규칙 적용: `live:rooms:{roomId}` → `live:room:{roomId}`, `live:rooms-map` → `live:room-map`
- 에러 체계 리팩토링: `internal/room/port/in/errors.go` → `internal/room/domain/errors/errors.go`로 이동, 공유 에러 정리


### How
- Redis 7.4부터 지원되는 `HEXPIRE key seconds FIELDS n field` 문법을 Lua 스크립트 안에서 `redis.call`로 호출
- `ARGV[6]`(TTL 초)과 `ARGV[7]`(mapField)은 기존 SaveRoom 호출부에서 이미 전달 중이므로 Go 코드 변경 없이 Lua 스크립트만 수정
- room key(`EXPIRE`)와 room-map 필드(`HEXPIRE`)가 동일한 TTL로 원자적으로 설정되어 만료 시점이 일치함


### Test
- `make test` 통과 확인
- 기존 `SaveRoom`, `DeleteRoom` 관련 단위 테스트 모두 통과
- RedisInsight(`localhost:5540`)에서 room-map 필드 TTL 적용 여부 직접 확인 가능